### PR TITLE
Add net-tools dependency

### DIFF
--- a/droneunit/Dockerfile.template
+++ b/droneunit/Dockerfile.template
@@ -1,11 +1,11 @@
 FROM {{ registry }}drone-busybee:{{ suite }}
 
 {% if dist in ('centos', 'fedora') -%}
-RUN yum -y install nc
+RUN yum -y install nc net-tools
 {%- else -%}
 # install core software for packaging and ssh communication
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
     apt-get -y install gdebi-core sshpass cron \
-      netcat
+      netcat net-tools
 {%- endif %}


### PR DESCRIPTION
Provides `netstat`, needed for "listening on port" Rspec tests, see:
https://github.com/StackStorm/st2-packages/pull/107

Apparently `net-tools` is the same package naming for both rpm/deb.
https://www.rpmfind.net/linux/rpm2html/search.php?query=%2Fbin%2Fnetstat
